### PR TITLE
Bugfix: impossible to set time_format=raw option in run

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -218,7 +218,7 @@ class RqlQuery {
           formatOpts = {"time_format": "native"};
         }
         String timeFormat = formatOpts['time_format'];
-        if (timeFormat != null || timeFormat == 'native') {
+        if (timeFormat == null || timeFormat == 'native') {
           // Convert to native dart DateTime
           return _reqlTypeTimeToDatetime(obj);
         } else if (timeFormat != 'raw')

--- a/lib/src/net.dart
+++ b/lib/src/net.dart
@@ -273,7 +273,7 @@ class Connection {
       if (response._data.length < 1) {
         value = null;
       }
-      value = query._recursivelyConvertPseudotypes(response._data.first, null);
+      value = query._recursivelyConvertPseudotypes(response._data.first, query._globalOptargs);
     } else if (response._type == p.Response_ResponseType.WAIT_COMPLETE.value) {
       //Noreply_wait response
       value = null;
@@ -461,7 +461,6 @@ class Connection {
     } else {
       globalOptargs['db'] = new DB(_db);
     }
-
     Query query =
         new Query(p.Query_QueryType.START, _getToken(), term, globalOptargs);
     _sendQueue.addLast(query);


### PR DESCRIPTION
Setting time_format option in run() did not work. This bugfix enables to set time_format=raw as documented.
Example:

r.db('some_db').table('some_table').pluck('some_datetime_field').run(conn, {'time_format': 'raw'});

Bugfix makes this query work correctly